### PR TITLE
Add opam file

### DIFF
--- a/bin/jbuild
+++ b/bin/jbuild
@@ -8,13 +8,11 @@
 
 (executable
  ((name DreJS_api)
-  (public_name DreJS_api)
   (modules DreJS_api)
   (libraries (js_of_ocaml lib))))
 
 (executable
  ((name DreJS_command)
   (modules DreJS_command)
-  (public_name DreJS_command)
   (js_of_ocaml ((flags (--custom-header "#!/usr/bin/env node"))))
   (libraries (js_of_ocaml lib))))

--- a/reason-dre.opam
+++ b/reason-dre.opam
@@ -1,0 +1,14 @@
+opam-version: "1.2"
+authors: "Ryan Delaney <rrdelaney@outlook.com>"
+maintainer: "Ryan Delaney <rrdelaney@outlook.com>"
+dev-repo: "https://github.com/rrdelaney/reason-dre.git"
+homepage: "https://github.com/rrdelaney/reason-dre"
+bug-reports: "https://github.com/rrdelaney/reason-dre/issues"
+build: ["jbuilder" "build" "-p" name]
+depends: [
+  "ocamlfind" {build}
+  "jbuilder" {build}
+  "reason" {>= "3.0.0"}
+  "js_of_ocaml" {>= "3.2.0"}
+  "flow-parser"
+]


### PR DESCRIPTION
This depends on https://github.com/esy-ocaml/flow-parser/pull/1 being merged (and preferably published).

Note that the last commit marks the JS CLI files as not to be installed by dune. You might want to cherry pick that commit, at least.